### PR TITLE
Decode RF messages [enhancement]

### DIFF
--- a/mochad_dispatch/main.py
+++ b/mochad_dispatch/main.py
@@ -122,21 +122,34 @@ class MochadClient:
         """
         Parse a raw line of output from mochad
         """
+        self.logger.info(line[15:19])
         # bail out unless it's an incoming RFSEC message
-        if line[15:23] != 'Rx RFSEC':
-            return '', ''
+        if line[15:23] == 'Rx RFSEC':
 
-        # decode message. format is either:
-        #   09/22 15:39:07 Rx RFSEC Addr: 21:26:80 Func: Contact_alert_min_DS10A
-        #     ~ or ~
-        #   09/22 15:39:07 Rx RFSEC Addr: 0x80 Func: Motion_alert_SP554A
-        line_list = line.split(' ')
-        addr = line_list[5]
-        func = line_list[7]
+            # decode message. format is either:
+            #   09/22 15:39:07 Rx RFSEC Addr: 21:26:80 Func: Contact_alert_min_DS10A
+            #     ~ or ~
+            #   09/22 15:39:07 Rx RFSEC Addr: 0x80 Func: Motion_alert_SP554A
+            line_list = line.split(' ')
+            addr = line_list[5]
+            func = line_list[7]
 
-        func_dict = self.decode_func(func)
+            func_dict = self.decode_func(func)
 
-        return addr, {'func': func_dict}
+            return addr, {'func': func_dict}
+
+        elif line[15:20] == 'Rx RF':
+
+            # decode RF message. format is:
+            #   02/13 23:54:28 Rx RF HouseUnit: B1 Func: On
+            line_list = line.split(' ')
+            house_code = line_list[5];
+            house_func = line_list[7]
+
+            return house_code, {'func': house_func}
+
+        return '', ''
+
 
     def decode_func(self, raw_func):
         """


### PR DESCRIPTION
This is the PR I mentioned in #9 to process RF commands received from mochad when X10 RF switch events, such as those from the HR12A, are received. I've tested it with a CM19A receiver, but it should be the same with the CM15A.

Right now these messages still create MQTT events under the "security" category, so we may want to add code to change that. 

Curious to know whether you think this is a useful addition. For myself, I've been using it for about a month. It fills a gap in my home automation solution, Home Assistant, since I could find no other way to trigger events when an X10 RF switch is pushed. The TCP sensor in HA is set up for polling, and therefore not very useful with mochad directly, however MQTT support works great!

FYI this is the format of the RF messages I get from mochad:

`02/13 23:54:28 Rx RF HouseUnit: B1 Func: On`