### PR TITLE
fix: explicit `long_description` is required for package docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,32 @@
 from setuptools import setup
 
-VERSION = '0.2.1'
+VERSION = "0.2.1.post3"
 
 REQUIRES = [
-    'paho-mqtt',
-    'pytz',
+    "paho-mqtt",
+    "pytz",
 ]
 
 setup(
-    name='mochad_dispatch',
+    name="mochad_dispatch",
     version=VERSION,
     description="mochad_dispatch is a daemon written in Python that translates mochad's tcp-based events to MQTT messages",
-    url='https://github.com/ChrisArgyle/mochad_dispatch',
-    download_url='https://github.com/ChrisArgyle/mochad_dispatch/archive/{}.zip'.format(VERSION),
-    author='Chris Przybycien',
-    author_email='chrisisdiy@gmail.com',
-    license='MIT',
-    packages=['mochad_dispatch'],
+    url="https://github.com/ChrisArgyle/mochad_dispatch",
+    download_url="https://github.com/ChrisArgyle/mochad_dispatch/archive/{}.zip".format(
+        VERSION
+    ),
+    author="Chris Przybycien",
+    author_email="chrisisdiy@gmail.com",
+    license="MIT",
+    packages=["mochad_dispatch"],
+    long_description=open("README.rst").read(),
     zip_safe=False,
     install_requires=REQUIRES,
-    test_suite='tests',
-    entry_points={
-        'console_scripts': [
-            'mochad_dispatch = mochad_dispatch.main:main'
-        ]
-    },
+    test_suite="tests",
+    entry_points={"console_scripts": ["mochad_dispatch = mochad_dispatch.main:main"]},
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.4',
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.4",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.2.1.post3"
+VERSION = "0.2.1"
 
 REQUIRES = [
     "paho-mqtt",


### PR DESCRIPTION
The package docs won't show up without explicitly defining `long_description`.  Oops!